### PR TITLE
Exclude plist file from target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,8 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "KMPlaceholderTextView"),
+            name: "KMPlaceholderTextView"
+            exclude: ["KMPlaceholderTextView/Info.plist"]
+        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -8,11 +8,12 @@ let package = Package(
     products: [
         .library(
             name: "KMPlaceholderTextView",
-            targets: ["KMPlaceholderTextView"]),
+            targets: ["KMPlaceholderTextView"]
+        ),
     ],
     targets: [
         .target(
-            name: "KMPlaceholderTextView"
+            name: "KMPlaceholderTextView",
             exclude: ["KMPlaceholderTextView/Info.plist"]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     targets: [
         .target(
             name: "KMPlaceholderTextView",
-            exclude: ["KMPlaceholderTextView/Info.plist"]
+            exclude: ["Info.plist"]
         ),
     ]
 )


### PR DESCRIPTION
A fix for the following warning:

<img src="https://user-images.githubusercontent.com/5849587/139406957-f5c2fa9b-202d-453d-a050-a39ad5e74136.png" width="700">
